### PR TITLE
Swap fetch implementation node-fetch -> isomorphic-fetch

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var catchNetworkErrors = require('./src/catch-network-errors');
-var fetch = require('node-fetch');
+require('isomorphic-fetch');
 
 module.exports = function(url, opts) {
 	var retriesLeft = opts.retry === undefined ? 3 : opts.retry;

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "n-eager-fetch",
   "version": "0.0.0",
   "main": "main.js",
-  "scripts" : {
+  "scripts": {
     "release": "npm-prepublish --verbose && npm publish && git checkout package.json"
   },
   "dependencies": {
     "ft-next-logger": "^1.1.2",
-    "next-build-tools": "^3.9.1",
-    "node-fetch": "^1.3.1"
+    "isomorphic-fetch": "^2.1.1",
+    "next-build-tools": "^3.9.1"
   },
   "devDependencies": {
     "npm-prepublish": "^1.2.0"


### PR DESCRIPTION
As discussed this ensures we use the global instance of `fetch`, which shall solve issues we have seen when testing with `fetch-mock`.

/cc @matthew-andrews @wheresrhys 