### PR TITLE
adds support for allowed status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Extension of fetch which supports passing a `retry` value in to `options`. `retry` should be an integer, `n`, and a fetch will be retried `n` times (i.e. `n + 1` fetches in total) before failing.
 
+Supports an `allowedStatusCodes` value in `options`. This is an array of integers of status codes that if responded with, won't attempt to retry.
+
 Fetches also have a `stopRetrying()` method which will fulfil the promise with the reult of the current in-flight fetch and not send any more requests

--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ module.exports = function (url, opts) {
 	opts.allowedStatusCodes = undefined;
 
 	const isNotWhiteListed = (status) => {
-		return allowedStatusCodes.indexOf(status) === -1;
+		return allowedStatusCodes && allowedStatusCodes.indexOf(status) === -1;
 	}
 
 	function fetchAttempt () {

--- a/main.js
+++ b/main.js
@@ -3,13 +3,19 @@ require('isomorphic-fetch');
 
 module.exports = function (url, opts) {
 	let retriesLeft = opts.retry === undefined ? 3 : opts.retry;
+	const allowedStatusCodes = opts.allowedStatusCodes;
 	opts.retry = undefined;
+	opts.allowedStatusCodes = undefined;
+
+	const isNotWhiteListed = (status) => {
+		return allowedStatusCodes.indexOf(status) === -1;
+	}
 
 	function fetchAttempt () {
 		const fetchCall = fetch(url, opts)
 			.catch(catchNetworkErrors)
 			.then(function (response) {
-				if (!response.ok && retriesLeft > 0) {
+				if (!response.ok && retriesLeft > 0 && isNotWhiteListed(response.status)) {
 					retriesLeft--;
 					return fetchAttempt();
 				}


### PR DESCRIPTION
This adds an option for allowing status codes. We found that we were getting 404 responses which would be tried again when we knew they wouldn't ever be successful.

Going forward maybe we could have an option that won't retry if a valid status code was returned but would retry if there was a network timeout.