### PR TITLE
[UNTESTED] Nullish coalescing for opts

### DIFF
--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ const catchNetworkErrors = require('./src/catch-network-errors');
 require('isomorphic-fetch');
 
 module.exports = function (url, opts) {
+	if (!opts) opts = {};
 	let retriesLeft = opts.retry === undefined ? 3 : opts.retry;
 	const allowedStatusCodes = opts.allowedStatusCodes || [];
 	opts.retry = undefined;


### PR DESCRIPTION
If you call eager fetch without an `options` parameter, it exits with a funky error message that leads to hours of wasted debugging and yes I'm tired and cranky and I want a mars bar ice cream but I can't have one because I'm trying to cut all carbs because I can't touch my toes